### PR TITLE
Replace `camelCase` Methods To The `snake_case` In Arithmetic Expression Notation Module.

### DIFF
--- a/arithmetic-expression-notation/expression_notation.c
+++ b/arithmetic-expression-notation/expression_notation.c
@@ -20,7 +20,7 @@ Stack *initial(unsigned capacity) {
 	return st;
 }
 
-int isEmpty(Stack *st) {
+int is_empty(Stack *st) {
 	return st->top == -1;
 }
 
@@ -30,7 +30,7 @@ int peek(Stack *st) {
 
 char pop(Stack *st) {
 	/* remove the top item of the stack  */
-	if(!isEmpty(st)) return st->items[st->top--];
+	if(!is_empty(st)) return st->items[st->top--];
 	return '$';	// if the stack is empty, return a `$`
 }
 
@@ -39,7 +39,7 @@ void push(Stack *st, char op) {
 	st->items[++st->top] = op;
 }
 
-int isOperand(char character) {
+int is_operand(char character) {
 	/* check if the character is alpha, return True, otherwise, return False  */
 	return (character >= 'a' && character <= 'z') || (character >= 'A' && character <= 'Z');
 }
@@ -55,4 +55,3 @@ int precedence(char character) {
 	}
 	return -1;
 }
-

--- a/arithmetic-expression-notation/expression_notation.h
+++ b/arithmetic-expression-notation/expression_notation.h
@@ -9,15 +9,14 @@ typedef struct stack {
 
 Stack *initial(unsigned capacity);
 
-int isEmpty(Stack *st);
+int is_empty(Stack *st);
 int peek(Stack *st);
 char pop(Stack *st);
 void push(Stack *st, char op);
 
-int isOperand(char character);
+int is_operand(char character);
 int precedence(char character);
 
-int infixToPostfix(char *expression);
+int infix_to_postfix(char *expression);
 
 #endif // EXPRESSION_NOTATION
-

--- a/arithmetic-expression-notation/in_to_post.c
+++ b/arithmetic-expression-notation/in_to_post.c
@@ -5,32 +5,32 @@
 #include "expression_notation.h"
 
 
-int infixToPostfix(char *expression) {
+int infix_to_postfix(char *expression) {
 	int i, k;
 
 	Stack *st;
 	st = initial(strlen(expression));	// initialize the stack by length of expression
 
-	if(!st) return -1;
-	for(i = 0, k = -1; expression[i]; ++i)
+	if (!st) return -1;
+	for (i = 0, k = -1; expression[i]; ++i)
 	{
-		/* check all the characters of the expression in the loop  
-		 * `k` increase when the character is operand*/
-
-		if(isOperand(expression[i])) expression[++k] = expression[i];
-		else if(expression[i] == '(') push(st, expression[i]);
-		else if(expression[i] == ')')
-		{
+		// check all the characters of the expression in the loop  
+		// `k` increase when the character is operand
+		if (is_operand(expression[i])) expression[++k] = expression[i];
+		else if ( expression[i] == '(' ) push(st, expression[i]);
+		else if ( expression[i] == ')' ) {
 			// while the Stack is empty and the top operator item isn't `(`, pop the items
-			while(!isEmpty(st) && peek(st) != '(') expression[++k] = pop(st);
-			if(!isEmpty(st) && peek(st) != '(') return -1;
+			while ( !is_empty(st) && peek(st) != '(' ) {
+				expression[++k] = pop(st);
+			}
+			if ( !is_empty(st) && peek(st) != '(' ) {
+				return -1;
+			}
 			else pop(st);	// pop the `(` and don't push it to the output expression
 		}
-		else
-		{
+		else {
 			/* check the operators  */
-
-			while( !isEmpty(st) && precedence(expression[i]) <= precedence(peek(st)) )
+			while ( !is_empty(st) && precedence(expression[i]) <= precedence(peek(st)) )
 			{
 				/* if the priority of the current operator character is less than the
 				 *  top item(top operator character) of the Stack, then pop it off the Stack. Otherwise,
@@ -40,8 +40,11 @@ int infixToPostfix(char *expression) {
 			push(st, expression[i]);	// push the operator character to the stack
 		}
 	}
-	while(!isEmpty(st)) expression[++k] = pop(st);
+
+	while (!is_empty(st)) {
+		expression[++k] = pop(st);
+	}
+
 	expression[++k] = '\0';	// Null-terminate the expression string
 	printf("%s\n", expression);
 }
-

--- a/arithmetic-expression-notation/main.c
+++ b/arithmetic-expression-notation/main.c
@@ -6,8 +6,7 @@
 
 int main() {
 	char ex[] = "a+b/(c*d+e)-f^g";
-	infixToPostfix(ex);
+	infix_to_postfix(ex);
 
 	return 0;
 }
-


### PR DESCRIPTION
## Replace `camelCase` Methods To The `snake_case` In Arithmetic Expression Notation Module.

## Description
<!-- Please include a summary of the change and which issue is fixed. -->
Replaced all `camleCase` methods to the `snake_case` in `/arithmetic-expression-notation` module.

---

## Changes
- Replaced all methods from `camelCase` to the `snake_case` in `/arithmetic-expression-notation/expression_notation.c`.
- Replaced all methods from `camelCase` to the `snake_case` in `/arithmetic-expression-notation/in_to_post.c`.
- Replaced all methods from `camelCase` to the `snake_case` in `/arithmetic-expression-notation/expression_notation.h`.
- Replaced all methods from `camelCase` to the `snake_case` in `/arithmetic-expression-notation/main.c`.

---

## Type of change
- [ ] Bug fix.
- [ ] New feature.
- [x] Breaking change.
- [ ] Documentation update.

## Tasks
- [x] Update code/docs/tests as needed
- [ ] Code changes implemented
- [ ] Documentation updated
- [ ] Tests updated/added
<!-- Other tasks if you had -->

---

## How has this been tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing
<!-- Other ways if you tested in other an other way -->

---

## Resolved Issues
#### Closes
- #38 

---
