### PR TITLE
Replace camelCase to SnakeCase In Queue Data Structure

### DIFF
--- a/data-structure/queue/circular_queue.c
+++ b/data-structure/queue/circular_queue.c
@@ -5,7 +5,7 @@
 #include "include/queue.h"
 
 
-CircularQueue *initialCicular(unsigned capacity) {
+CircularQueue *init_circular_queue(unsigned capacity) {
 	CircularQueue *q;
 	q = (CircularQueue*) malloc(sizeof(CircularQueue));
 
@@ -15,7 +15,7 @@ CircularQueue *initialCicular(unsigned capacity) {
 	q->size = capacity;
 }
 
-void enqueueCicular(CircularQueue *q, int item) {
+void enqueue_circular(CircularQueue *q, int item) {
 	if( (q->front == 0 && q->rear == q->size - 1) || (q->rear == q->front - 1) )
 	{
 		printf("\nThe Queue is full.");
@@ -42,7 +42,7 @@ void enqueueCicular(CircularQueue *q, int item) {
 }
 
 
-int dequeueCicular(CircularQueue *q) {
+int dequeue_circular(CircularQueue *q) {
 	int item = q->items[q->front];
 	q->items[q->front] = -1;
 

--- a/data-structure/queue/include/queue.h
+++ b/data-structure/queue/include/queue.h
@@ -10,10 +10,10 @@ typedef struct queue {
     unsigned capacity;
 } RegularQueue;
 
-int isFull(RegularQueue *q);
-int isEmpty(RegularQueue *q);
+int is_full(RegularQueue *q);
+int is_empty(RegularQueue *q);
 
-RegularQueue *initialRegular(unsigned capacity);
+RegularQueue *init_regular_queue(unsigned capacity);
 void enqueue(RegularQueue *q, int item);
 int dequeue(RegularQueue *q);
 
@@ -27,9 +27,9 @@ typedef struct circularQueue {
 } CircularQueue;
 
 
-CircularQueue *initialCicular(unsigned capacity);
-void enqueueCicular(CircularQueue *q, int item);
-int dequeueCicular(CircularQueue *q);
+CircularQueue *init_circular_queue(unsigned capacity);
+void enqueue_circular(CircularQueue *q, int item);
+int dequeue_circular(CircularQueue *q);
 void show(CircularQueue *q);
 
 #endif // QUEUE_H

--- a/data-structure/queue/include/queue_linked_list.h
+++ b/data-structure/queue/include/queue_linked_list.h
@@ -13,14 +13,14 @@ typedef struct queue_linked_list {
 	unsigned capacity;
 } RegularQueueLinkedList;
 
-Node *initialNodeSingly(int value);
-RegularQueueLinkedList *initialRegularQueueLinkedList(unsigned capacity);
+Node *init_node_singly(int value);
+RegularQueueLinkedList *init_regular_queue_linked_list(unsigned capacity);
 
-void enqueueLinkedList(RegularQueueLinkedList *q, int item);
-void dequeueLinkedList(RegularQueueLinkedList *q);
+void enqueue_linked_list(RegularQueueLinkedList *q, int item);
+void dequeue_linked_list(RegularQueueLinkedList *q);
 
-int isEmptyRegularQLL(RegularQueueLinkedList *q);
-int getFront(RegularQueueLinkedList *q);
-int getRear(RegularQueueLinkedList *q);
+int is_empty_regular_queue_linked_list(RegularQueueLinkedList *q);
+int get_front(RegularQueueLinkedList *q);
+int get_rear(RegularQueueLinkedList *q);
 
 #endif // QUEUE_LINKEDLIST_H

--- a/data-structure/queue/main.c
+++ b/data-structure/queue/main.c
@@ -11,7 +11,7 @@ int main() {
     printf("\nThe Regular Queue Test In Main:\n\n");
 
 	RegularQueue *regularQ;
-	regularQ = initialRegular(5);
+	regularQ = init_regular_queue(5);
 	enqueue(regularQ, 1);
 	enqueue(regularQ, 3);
 
@@ -29,15 +29,15 @@ int main() {
     printf("\nThe Circular Queue Test In Main:\n\n");
 
     CircularQueue *circularQ;
-	circularQ = initialCicular(4);
-	enqueueCicular(circularQ, 3);
-	enqueueCicular(circularQ, 6);
-	enqueueCicular(circularQ, 9);
+	circularQ = init_circular_queue(4);
+	enqueue_circular(circularQ, 3);
+	enqueue_circular(circularQ, 6);
+	enqueue_circular(circularQ, 9);
 	printf("\tBefore Deletion Action:");
 	show(circularQ);
 
 	printf("\n\n\tAfter Deletion Action:");
-	int item = dequeueCicular(circularQ);
+	int item = dequeue_circular(circularQ);
 	show(circularQ);
 	printf("\n\n");
 
@@ -48,15 +48,15 @@ int main() {
 	printf("\nThe Regular Queue Linked List, Test In Main:\n\n");
 
 	RegularQueueLinkedList *regularQLL;	// initialize a new Regular Queue Linked List
-	regularQLL = initialRegularQueueLinkedList(4);
-	enqueueLinkedList(regularQLL, 7);
-	enqueueLinkedList(regularQLL, 9);
-	enqueueLinkedList(regularQLL, 2);
-	printf("\tThe Front Of Queue: %d\n", getFront(regularQLL));
-	printf("\tThe Rear Of Queue: %d\n", getRear(regularQLL));
+	regularQLL = init_regular_queue_linked_list(4);
+	enqueue_linked_list(regularQLL, 7);
+	enqueue_linked_list(regularQLL, 9);
+	enqueue_linked_list(regularQLL, 2);
+	printf("\tThe Front Of Queue: %d\n", get_front(regularQLL));
+	printf("\tThe Rear Of Queue: %d\n", get_rear(regularQLL));
 
-	dequeueLinkedList(regularQLL);
-	printf("\n\tThe Front Of Queue After Deletion: %d\n", getFront(regularQLL));
+	dequeue_linked_list(regularQLL);
+	printf("\n\tThe Front Of Queue After Deletion: %d\n", get_front(regularQLL));
 
 	printf("\n");
 

--- a/data-structure/queue/regular_queue.c
+++ b/data-structure/queue/regular_queue.c
@@ -5,7 +5,7 @@
 #include "include/queue.h"
 
 
-RegularQueue *initialRegular(unsigned capacity) {
+RegularQueue *init_regular_queue(unsigned capacity) {
 	RegularQueue *q;
 	q = (RegularQueue*) malloc(sizeof(RegularQueue));
 
@@ -18,13 +18,13 @@ RegularQueue *initialRegular(unsigned capacity) {
 	return q;
 }
 
-int isFull(RegularQueue *q) { return (q->size == q->capacity); }
-int isEmpty(RegularQueue *q) { return (q->size == 0); }
+int is_full(RegularQueue *q) { return (q->size == q->capacity); }
+int is_empty(RegularQueue *q) { return (q->size == 0); }
 
 void enqueue(RegularQueue *q, int item) {
 	int tmp;
 
-	if(isFull(q)) return;
+	if(is_full(q)) return;
 
 	q->rear = (q->rear + 1) % q->capacity;
 	tmp = q->rear;
@@ -37,7 +37,7 @@ void enqueue(RegularQueue *q, int item) {
 int dequeue(RegularQueue *q) {
 	int item, tmp;
 
-	if(isEmpty(q)) return INT_MIN;
+	if(is_empty(q)) return INT_MIN;
 
 	tmp = q->front;
 	item = q->items[tmp];

--- a/data-structure/queue/regular_queue_linked_list.c
+++ b/data-structure/queue/regular_queue_linked_list.c
@@ -5,7 +5,7 @@
 #include "include/queue_linked_list.h"
 
 
-Node *initialNodeSingly(int value) {
+Node *init_node_singly(int value) {
     /* initial (create) a new node */
     Node *new_node = (Node*) malloc(sizeof(Node));
 
@@ -19,7 +19,7 @@ Node *initialNodeSingly(int value) {
     }
 }
 
-RegularQueueLinkedList *initialRegularQueueLinkedList(unsigned capacity) {
+RegularQueueLinkedList *init_regular_queue_linked_list(unsigned capacity) {
     /* initial (create) a new regular queue with singly linked list */
     RegularQueueLinkedList *q;
     q = (RegularQueueLinkedList*) malloc(sizeof(RegularQueueLinkedList));
@@ -31,7 +31,7 @@ RegularQueueLinkedList *initialRegularQueueLinkedList(unsigned capacity) {
     return q;
 }
 
-int isEmptyRegularQLL(RegularQueueLinkedList *q) {
+int is_empty_regular_queue_linked_list(RegularQueueLinkedList *q) {
     /*  RegularQLL = Regular Queue Linked List 
         Check if the queue is empty or not!
     */
@@ -39,8 +39,8 @@ int isEmptyRegularQLL(RegularQueueLinkedList *q) {
     return 0;
 }
 
-void enqueueLinkedList(RegularQueueLinkedList *q, int item) {
-    Node *new_node = initialNodeSingly(item);    // initialize a new node
+void enqueue_linked_list(RegularQueueLinkedList *q, int item) {
+    Node *new_node = init_node_singly(item);    // initialize a new node
     
     if(q->rear == NULL) {
         /* if queue is empty, the new node is both the front and rear */
@@ -51,12 +51,12 @@ void enqueueLinkedList(RegularQueueLinkedList *q, int item) {
     q->rear = new_node;    // change the rear
 }
 
-void dequeueLinkedList(RegularQueueLinkedList *q) {
+void dequeue_linked_list(RegularQueueLinkedList *q) {
     /* delete the front item of the queue and deallocate the memory of the item */
     
     Node *temp = q->front;
     
-    if(isEmptyRegularQLL(q))
+    if(is_empty_regular_queue_linked_list(q))
     {
         printf("Queue Underflow...\n");
         return;
@@ -69,8 +69,8 @@ void dequeueLinkedList(RegularQueueLinkedList *q) {
     free(temp); // deallocate the memory of the old front node
 }
 
-int getFront(RegularQueueLinkedList *q) {
-    if(isEmptyRegularQLL(q))
+int get_front(RegularQueueLinkedList *q) {
+    if(is_empty_regular_queue_linked_list(q))
     {
         printf("Queue Is Empty...\n");
         return INT_MIN;
@@ -78,8 +78,8 @@ int getFront(RegularQueueLinkedList *q) {
     return q->front->data;
 }
 
-int getRear(RegularQueueLinkedList *q) {
-    if(isEmptyRegularQLL(q))
+int get_rear(RegularQueueLinkedList *q) {
+    if(is_empty_regular_queue_linked_list(q))
     {
         printf("Queue Is Empty...\n");
         return INT_MIN;


### PR DESCRIPTION
## Replace camelCase to SnakeCase In Queue Data Structure

## Description
<!-- Please include a summary of the change and which issue is fixed. -->
Replace all `camelCase` methods to the `snake_case` in `/data-structure/queue` module.

---

## Changes
- Replaced all `camelCase` methods to `snake_case` in `/data-structure/queue/regular_queue.c`.
- Replaced all `camelCase` methods to `snake_case` in `/data-structure/queue/circular_queue.c`.
- Replaced all `camelCase` methods to `snake_case` in `/data-structure/queue/regular_queue_linked_list.c`.
- Replaced all `camelCase` methods to `snake_case` in `/data-structure/queue/main.c`.
- Replaced all `camelCase` methods to `snake_case` in `/data-structure/queue/include/queue.h`.
- Replaced all `camelCase` methods to `snake_case` in `/data-structure/queue/include/queue_linked_list.h`.

---

## Type of change
- [ ] Bug fix.
- [ ] New feature.
- [x] Breaking change.
- [ ] Documentation update.

## Tasks
- [x] Update code/docs/tests as needed
- [ ] Code changes implemented
- [ ] Documentation updated
- [ ] Tests updated/added
<!-- Other tasks if you had -->

---

## How has this been tested?
- [ ] Unit tests
- [x] Integration tests
- [x] Manual testing
<!-- Other ways if you tested in other an other way -->

---

## Resolved Issues
#### Closes
- #42 

---
